### PR TITLE
fix: fixed kubeedge config and removed quic port from service

### DIFF
--- a/dev/hack/install-certs-on-device.sh
+++ b/dev/hack/install-certs-on-device.sh
@@ -31,7 +31,7 @@ if [ ! -f "$nodePublicKey" ] ||  [ ! -f "$nodePrivateKey" ]; then
     devspace run mkcert.create-client-cert kubeedge \
     -cert-file ${nodePublicKey} \
     -key-file ${nodePrivateKey} *.nip.io *.edgefarm.local
-fi 
+fi
 
 scp ${rootCa} root@${deviceIP}:/etc/kubeedge/certs/
 scp ${nodePublicKey} root@${deviceIP}:/etc/kubeedge/certs/

--- a/dev/hack/kubeedge-node/edgecore.yaml.TEMPLATE
+++ b/dev/hack/kubeedge-node/edgecore.yaml.TEMPLATE
@@ -12,7 +12,7 @@ modules:
   edgeHub:
     enable: true
     heartbeat: 15
-    httpServer: https://${CLOUDCORE_ADDRESS}:30002
+    httpServer: https://${CLOUDCORE_ADDRESS}:10002
     projectID: e632aba927ea4ac2b575ec1603d56f10
     quic:
       enable: false
@@ -24,13 +24,13 @@ modules:
       enable: true
       handshakeTimeout: 30
       readDeadline: 15
-      server: ${CLOUDCORE_ADDRESS}:30000
+      server: ${CLOUDCORE_ADDRESS}:10000
       writeDeadline: 15
   edgeStream:
     enable: true
     handshakeTimeout: 30
     readDeadline: 15
-    server: ${CLOUDCORE_ADDRESS}:30004
+    server: ${CLOUDCORE_ADDRESS}:10004
     tlsTunnelCAFile: /etc/kubeedge/certs/rootCa.pem
     tlsTunnelCertFile: /etc/kubeedge/certs/node.pem
     tlsTunnelPrivateKeyFile: /etc/kubeedge/certs/node.key

--- a/manifests/kubeedge/cloudcore/service.yaml
+++ b/manifests/kubeedge/cloudcore/service.yaml
@@ -11,9 +11,6 @@ spec:
     - port: 10000
       targetPort: 10000
       name: cloudhub
-    - port: 10001
-      targetPort: 10001
-      name: cloudhub-quic
     - port: 10002
       targetPort: 10002
       name: cloudhub-https


### PR DESCRIPTION
The quic port is not used at all by our kubeedge instance. So removed it from the service.